### PR TITLE
Update clsSharedParameters.vb

### DIFF
--- a/src/Case.Subs.SharedParameters/Case.Subs.SharedParameters.SharedProject/Data/clsSharedParameters.vb
+++ b/src/Case.Subs.SharedParameters/Case.Subs.SharedParameters.SharedProject/Data/clsSharedParameters.vb
@@ -108,12 +108,12 @@ Namespace Data
             End If
 #End If
            #If Revit2022 Or Revit2023
-              If Not DefinitionsByType.ContainsKey(d.GetDataType().ToString) Then
+              If Not DefinitionsByType.ContainsKey(LabelUtils.GetLabelForSpec(d.GetDataType)) Then
                   Dim m_dList As New List(Of Definition)
                   m_dList.Add(d)
-                  DefinitionsByType.Add(d.GetDataType().ToString, m_dList)
+                  DefinitionsByType.Add(LabelUtils.GetLabelForSpec(d.GetDataType), m_dList)
               Else
-                  DefinitionsByType(d.GetDataType().ToString).Add(d)
+                  DefinitionsByType(LabelUtils.GetLabelForSpec(d.GetDataType)).Add(d)
               End If
 #End If
 


### PR DESCRIPTION
With that fix you will be able to see parameter data type instead of ForgeTypeId
![image](https://github.com/johnpierson/case-apps/assets/55183821/fe1440fb-dd3d-41d6-9a3d-70419ffefe74)
